### PR TITLE
add initial flag  configurable via env

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/tylerconlee/SlabAPI
 
 go 1.13
 
-require github.com/gorilla/mux v1.7.3
+require (
+	github.com/gorilla/mux v1.7.3
+	github.com/namsral/flag v1.7.4-pre
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/namsral/flag v1.7.4-pre h1:b2ScHhoCUkbsq0d2C15Mv+VU8bl8hAXV8arnWiOHNZs=
+github.com/namsral/flag v1.7.4-pre/go.mod h1:OXldTctbM6SWH1K899kPZcf65KxJiD7MsceFUpB5yDo=

--- a/main.go
+++ b/main.go
@@ -1,5 +1,15 @@
 package main
 
+import (
+	"github.com/namsral/flag"
+)
+
+var (
+	nrConfig string
+)
+
 func main() {
+	flag.StringVar(&nrConfig, "newrelic", "", "New Relic configuration key")
+	flag.Parse()
 	NewRouter()
 }


### PR DESCRIPTION
Add in namsral/flag and add initial flag configuration. namsral/flag allows flags to be passed at the command line, similar to the default flag pkg behavior, but it also allows for those flags to be set via an environment variable. 
The first flag added is for a New Relic configuration key. Additional flags can be added by adding a `flag.<TYPE>Var(<variable-for-flag>, <flag>, <default-value>, <description>)`