### PR TITLE
add newrelic configuration and initialize gorilla/mux package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,6 @@ go 1.13
 require (
 	github.com/gorilla/mux v1.7.3
 	github.com/namsral/flag v1.7.4-pre
-	github.com/newrelic/go-agent/v3 v3.0.0-20191211190617-d01b4de3d68e
+	github.com/newrelic/go-agent/v3 v3.0.0
+	github.com/newrelic/go-agent/v3/integrations/nrgorilla v1.0.0
 )

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.13
 require (
 	github.com/gorilla/mux v1.7.3
 	github.com/namsral/flag v1.7.4-pre
+	github.com/newrelic/go-agent/v3 v3.0.0-20191211190617-d01b4de3d68e
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,12 @@
+github.com/gorilla/mux v1.7.0/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/namsral/flag v1.7.4-pre h1:b2ScHhoCUkbsq0d2C15Mv+VU8bl8hAXV8arnWiOHNZs=
 github.com/namsral/flag v1.7.4-pre/go.mod h1:OXldTctbM6SWH1K899kPZcf65KxJiD7MsceFUpB5yDo=
+github.com/newrelic/go-agent v3.0.0+incompatible h1:OVbR4jHZfsqK50qz08yi2hxPvESVbZ7uhPbfihytcWE=
 github.com/newrelic/go-agent/v3 v3.0.0-20191211190617-d01b4de3d68e h1:2OLOH0YuoTqKiHbm4pKyIRPOgWd7oDKCOcS3fcrifhM=
 github.com/newrelic/go-agent/v3 v3.0.0-20191211190617-d01b4de3d68e/go.mod h1:H28zDNUC0U/b7kLoY4EFOhuth10Xu/9dchozUiOseQQ=
+github.com/newrelic/go-agent/v3 v3.0.0 h1:YK9ddXLcMoWr/Bqj30T+cQo1wniFVR5SS/mVuVTGKS8=
+github.com/newrelic/go-agent/v3 v3.0.0/go.mod h1:H28zDNUC0U/b7kLoY4EFOhuth10Xu/9dchozUiOseQQ=
+github.com/newrelic/go-agent/v3/integrations/nrgorilla v1.0.0 h1:PI4E7ZAs5TQqNy7kEMEtqjXmbJ93ztxhT2qLkAEcNtE=
+github.com/newrelic/go-agent/v3/integrations/nrgorilla v1.0.0/go.mod h1:1XnCVdRSKjS5ikMycFh7VKXBkk0oYPaKQb+sd6aSCoA=

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/namsral/flag v1.7.4-pre h1:b2ScHhoCUkbsq0d2C15Mv+VU8bl8hAXV8arnWiOHNZs=
 github.com/namsral/flag v1.7.4-pre/go.mod h1:OXldTctbM6SWH1K899kPZcf65KxJiD7MsceFUpB5yDo=
+github.com/newrelic/go-agent/v3 v3.0.0-20191211190617-d01b4de3d68e h1:2OLOH0YuoTqKiHbm4pKyIRPOgWd7oDKCOcS3fcrifhM=
+github.com/newrelic/go-agent/v3 v3.0.0-20191211190617-d01b4de3d68e/go.mod h1:H28zDNUC0U/b7kLoY4EFOhuth10Xu/9dchozUiOseQQ=

--- a/main.go
+++ b/main.go
@@ -1,15 +1,35 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/namsral/flag"
+	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
 var (
 	nrConfig string
+
+	nrApp *newrelic.Application
 )
 
 func main() {
 	flag.StringVar(&nrConfig, "newrelic", "", "New Relic configuration key")
 	flag.Parse()
+	hostname, err := os.Hostname()
+	if err != nil {
+
+	}
+	if nrConfig != "" {
+		appname := fmt.Sprintf("slabAPI %s", hostname)
+		nrApp, err = newrelic.NewApplication(
+			newrelic.ConfigAppName(appname),
+			newrelic.ConfigLicense(nrConfig),
+		)
+		if err != nil {
+
+		}
+	}
 	NewRouter()
 }

--- a/router.go
+++ b/router.go
@@ -13,7 +13,7 @@ import (
 func NewRouter() {
 	r := mux.NewRouter()
 	r.HandleFunc("/", IndexRouter)
-	http.Handle("/", r)
+	http.ListenAndServe(":8000", r)
 }
 
 // IndexRouter is the root level endpoint that's returned when a user requests the "/" endpoint.

--- a/router.go
+++ b/router.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/newrelic/go-agent/v3/integrations/nrgorilla"
 )
 
 // NewRouter initializes a new router, or map, for any request incoming to the API.
@@ -13,7 +14,7 @@ import (
 func NewRouter() {
 	r := mux.NewRouter()
 	r.HandleFunc("/", IndexRouter)
-	http.ListenAndServe(":8000", r)
+	http.ListenAndServe(":8000", nrgorilla.InstrumentRoutes(r, nrApp))
 }
 
 // IndexRouter is the root level endpoint that's returned when a user requests the "/" endpoint.


### PR DESCRIPTION
One of the integrations that New Relic's Go Agent provides is for the gorilla/mux framework, which is used in this project to route incoming API requests. Because the integration is already there, any usage of the framework should automatically be instrumented by New Relic, alleviating a lot of the busywork needed to instrument each route manually.